### PR TITLE
adding notes 24 july RCM team

### DIFF
--- a/project-management/team-meetings/2023-07-24-rcm-meetings.md
+++ b/project-management/team-meetings/2023-07-24-rcm-meetings.md
@@ -1,0 +1,105 @@
+> ---
+tags: meeting
+description: team meeting
+---
+
+[TOC]
+
+## Agenda
+
+* **Theme**: Open Agenda – suggest points below
+* **Chair**: Anne
+* **Links & resources:**
+
+### Attendees
+* Sophia
+* Emma
+* Anne
+* Malvika
+* Cass
+
+### Apologies
+> *Please add your name below if you are not able to attend the meeting.*
+* Clau - at the Summer Experience for the day!
+* Vicky - at UKRN retreat
+* Gabin on holiday
+* Eirini - not feeling well!
+* 
+
+## Name + Agenda Collection
+> ***Name** / **Agenda point** raised at this meeting (update from your project, something you recently worked on (or still working on) and issues to discuss with others) / **Links or resources** relevant to your agenda point? Even if you are missing this meeting, please fill in this section - other team members will take notes for later access.* 
+* [name=Anne] Organising inclusive events: as Book Dash planning picks up, would love to learn more about people's experiences (within & beyond the Turing!)
+* [name=Cass] Customer relationship management (CRM) tool for RCM e.g. [this free template](https://docs.google.com/spreadsheets/d/1EwLkYUE_zS33uw4VZUcldNJrL-p4FeWB3rybYnSOLKw/edit#gid=1014948252). TRIC-DT looking at using something similar to centrally record and manage stakeholder interactions. Also being discussed as a tool for RAMs. 
+    * AIM-RSF has been having the same conversations - would love insight/discussion as we haven't solved it. 
+* [name=Cass] Revisit or document how we store team meeting notes (see [this thread on slack](https://alan-turing-institute.slack.com/archives/C04RN9A6Z6C/p1689074471369659))
+    * CGVP: Are our notes stored on Github (from across TPS)? Answer currently is no.
+    * CGVP: Role of archiving the minutes & role of maintaining accountability 
+    * MS: There may be things that folks don't want to be shared. Pushing notes are also another step. Materials are available through other meta-resources currently through other means.
+    * ALS: Could part of the HackMD be pushed online? Can the goatherder be the one pushing notes to the repository?
+    * MS: There used to be something called 'Asked and Offer' that hasn't been used. Inherent RCM knowledge system being shared here. Can this be something in the wiki?
+    * CGVP: Clarifying, MS is wanting to share a selection for the team. ALS suggesting sharing minutes with a selection not being shared. I'm thinking about radical transparency bit, so this is a record of conversation about decision. Can everything be put out there? 
+    * MS: How do we make sure information is easy to find? Question is around 'what's the point of the transparency'?
+    * CGVP: For ambassadors, each week we shared notes: https://git.fmrib.ox.ac.uk/open-science/community/open-win-ambassadors/-/tree/master/call-notes
+    * MS: The CM team has a membership limit, if we make this public, then 
+    * SB: REG team has a processes question around how they work
+        * Document 1: https://alan-turing-institute.github.io/REG-handbook/docs/how_we_work/knowledge_sharing/
+        * Document 2: They also have https://alan-turing-institute.github.io/REG-handbook/docs/how_we_work/meeting_record/
+    * CGVP: Github data privacy may change how we use HackMD.
+    * MS: We previously had a practices of putting personal information in previous HackMDs. But the community clinics should be put online. 
+    * EK: We shouldn't be sharing personal stuff, but maybe we can pull out the clinics?
+    * ALS: Could we use the emoji 'shh' practice?
+    * MS: Not established norm for the RCM team. Also might not work for AIM-RSF team.
+    * SB: Notes could be used in a way that might have malicious effect on people.
+    * MS: Outcomes can be 1. How can we make sure that notes are structured in way that can be shared and 2. How can we make sure that folks know that notes will be shared so that compromising information won't be shared.
+    * CGVP: How do we go about redacting? Or is this going forward?
+    * MS: Going forward we can do this. But 2022-2023 documents can be summarisd. 
+        * To confirm, the goatherd schedule is not pubished (only shared internally) and confidential information is contained in the the hackmds linked from there 
+    * ALS: How should we go about reviewing previous notes?
+    * MS: Let's start with doing this going forward, and not reviewing these yet!
+* [name=Malvika Sharan] Team day agenda: https://hackmd.io/@cm-team/rkj48Z3ch
+    * ALS: Let's share this openly to the wider team over the course of the week.
+
+### Resource update
+*Before the meeting please update the [resource link](https://docs.google.com/spreadsheets/d/1pegEKZe0l6txwvJi1w8BB2OMzH3ov7tASH8ziC8xg5k/edit#gid=0), action on issues/PRs on the [GitHub repo](https://github.com/alan-turing-institute/open-community-building) that you have been assigned to or other responsibilities/tasks you have pending for the CM team you have been working on. Add a sentence below updating the team about it.*
+
+* [name=Cass] There are a bunch of issues about what should go into the RCM wiki ([#225](https://github.com/alan-turing-institute/open-research-community-management/issues/225), [#226](https://github.com/alan-turing-institute/open-research-community-management/issues/226), [#219](https://github.com/alan-turing-institute/open-research-community-management/issues/219), [#205](https://github.com/alan-turing-institute/open-research-community-management/issues/205), related [#191](https://github.com/alan-turing-institute/open-research-community-management/issues/119)) - can these be consolidated?
+    * [name=Anne] Can add TTW templates to this!
+* [name=Cass] Close [#226](https://github.com/alan-turing-institute/open-research-community-management/issues/226)?
+* [name=Cass] Wiki "edit this page" issue [#230](https://github.com/alan-turing-institute/open-research-community-management/issues/230) - who to assign to? Aaron mentioned this was tricky.
+    * Broken 'edit this page' link -> Cass now assigned
+    * Quarto closer to Jekyll
+    * Cass giving it a first crack!
+* [name=Anne] Finishing preparing briefing notes this week -. Is there an issue for this, and/or should we make it at this meeting? Also adding more to our shared workflow & outputs document [here](https://docs.google.com/spreadsheets/d/1pegEKZe0l6txwvJi1w8BB2OMzH3ov7tASH8ziC8xg5k/edit#gid=0).
+    * [name=Cass] Was there an issue for this? Please let me know which are ready to review? - I'll look at these at the end of the month
+
+### Notes
+> Notetakers: 
+*  Keeping Github issues as a standing issue for the team - preparing the Quarto wiki for the CM team
+*  Notes for points are above
+
+
+### Action points for follow up
+*Please move this to GitHub as a new issue: https://github.com/alan-turing-institute/open-community-building/issues.*
+* Update goatherd actions to inlcude the following actions after each call
+    * redact confidential information 
+    * remove links to goatherd
+    * remove zoom links
+    * Check that it looks good on github (ALS to look at it this week and save as a template)
+* ALS - adding these notes for this week under project management
+* All - people done with briefing notes, can get started with archiving on at Wednesday coworking call
+
+*End of the meeting*
+
+### Next Meeting
+
+* **Next week**
+    * Chair: Sarah
+    * Documentarian: [name]
+    * Theme: Theme: Analysing partipation/engagement using attendee data
+    * Speaker: Eirini and Clau
+
+### Information and Links  
+
+* Link of links: https://hackmd.io/@cm-team/link-of-links
+* Shared calendar with meeting times: https://calendar.google.com/calendar/u/0?cid=cGtlazVnc2xkcjlwYWRhNjc4MTJyaGtiaW9AZ3JvdXAuY2FsZW5kYXIuZ29vZ2xlLmNvbQ
+* GitHub for the project repo: https://github.com/alan-turing-institute/community-manager-team


### PR DESCRIPTION
Following up on @cassgvp's point about how we archive notes as a team, the 'meetings' folder in the RCM will be used to document team meeting notes going forward. Is this archive missing anything, or should anything be removed?